### PR TITLE
Only use exclusive (write) guards with the enclave RwLock.

### DIFF
--- a/app/server/src/protocol/attestation.rs
+++ b/app/server/src/protocol/attestation.rs
@@ -126,9 +126,9 @@ pub fn end_session(
 
 impl Attestation for Lockbox{
     fn session_request(&self, id_msg: &EnclaveIDMsg) -> Result<DHMsg1> {
-	self.enclave().say_something(String::from("doing session request"));
+	self.enclave_mut().say_something(String::from("doing session request"));
 	
-	match self.enclave().session_request(id_msg) {
+	match self.enclave_mut().session_request(id_msg) {
 	    Ok(r) => Ok(r),
 	    Err(e) => Err(LockboxError::Generic(format!("session_request: {}",e)))
 	}
@@ -154,18 +154,18 @@ impl Attestation for Lockbox{
     }
     
     fn end_session(&self) -> Result<()> {
-	self.enclave().say_something(String::from("doing end session"));
+	self.enclave_mut().say_something(String::from("doing end session"));
 	
 	Ok(())
     }
 
     fn enclave_id(&self) -> EnclaveIDMsg {
 	println!("...calling enclave.geteid()...");
-        EnclaveIDMsg { inner: self.enclave().geteid() }
+        EnclaveIDMsg { inner: self.enclave_mut().geteid() }
     }
 
     fn test_create_session(&self) -> Result<()> {
-	match self.enclave().test_create_session() {
+	match self.enclave_mut().test_create_session() {
 	    Ok(r) => {
 		Ok(())
 	    },
@@ -174,7 +174,7 @@ impl Attestation for Lockbox{
     }
     
     fn proc_msg1(&self, dh_msg1: &DHMsg1) -> Result<DHMsg2> {
-	match self.enclave().proc_msg1(dh_msg1) {
+	match self.enclave_mut().proc_msg1(dh_msg1) {
 	    Ok(r) => {
 		Ok(r)
 	    },
@@ -222,7 +222,7 @@ impl Attestation for Lockbox{
 		Ok(x) => {
 		    self.enclave_mut().set_ec_key(Some(x));
 		    self.enclave_mut().set_ec_key_enclave(x);
-		    Ok(*self.enclave().get_ec_key())
+		    Ok(*self.enclave_mut().get_ec_key())
 		},
 		Err(e) => return Err(LockboxError::Generic(format!("sealed enclave key format error: {:?}", e))),
 	    },

--- a/app/server/src/protocol/ecdsa.rs
+++ b/app/server/src/protocol/ecdsa.rs
@@ -101,8 +101,8 @@ impl Ecdsa for Lockbox {
 	
 	let (key_gen_first_mess, sealed_secrets) =
 	    if key_gen_msg1.protocol == Protocol::Deposit {
-		let mut rsd1 = self.enclave().get_random_ec_fe_log().unwrap();
-		match self.enclave().first_message(&mut rsd1) {
+		let mut rsd1 = self.enclave_mut().get_random_ec_fe_log().unwrap();
+		match self.enclave_mut().first_message(&mut rsd1) {
 		    Ok(x) => x,
 		    Err(e) => return Err(LockboxError::Generic(format!("generating first message: {}", e)))
 		}
@@ -110,7 +110,7 @@ impl Ecdsa for Lockbox {
 		let cf_ku = &self.database.cf_handle("ecdsa_keyupdate").unwrap();
 		match self.get_sealed_secrets(cf_ku, &key_gen_msg1.shared_key_id){
 		    Ok(mut sealed_in) =>{
-			match self.enclave().first_message_transfer(&mut sealed_in.0) {
+			match self.enclave_mut().first_message_transfer(&mut sealed_in.0) {
 			    Ok(x) => x,
 			    Err(e) => return Err(LockboxError::Generic(format!("{}", e))),
 			}
@@ -134,7 +134,7 @@ impl Ecdsa for Lockbox {
 	println!("second_message: get sealed secrets");
 	let (mut sealed_secrets, user_db_key) = self.get_sealed_secrets(cf_in, &key_gen_msg2.shared_key_id)?;
 	println!("second_message: got sealed secrets");
-	match self.enclave().second_message(&mut sealed_secrets, &key_gen_msg2) {
+	match self.enclave_mut().second_message(&mut sealed_secrets, &key_gen_msg2) {
 	    Ok(x) => {
 		self.database.put_cf(cf_out, user_db_key, &x.1)?;
 		Ok(Some(x.0))
@@ -148,7 +148,7 @@ impl Ecdsa for Lockbox {
 	let cf_out = &self.database.cf_handle("ecdsa_sign_first").unwrap();
 	let (mut sealed_secrets, user_db_key) = self.get_sealed_secrets(cf_in, &sign_msg1.shared_key_id)?;
 	
-	match self.enclave().sign_first(&mut sealed_secrets, &sign_msg1) {
+	match self.enclave_mut().sign_first(&mut sealed_secrets, &sign_msg1) {
 	    Ok(x) => {
 		match x {
 		    Some(x) => {
@@ -169,7 +169,7 @@ impl Ecdsa for Lockbox {
 	let (mut sealed_secrets, user_db_key) = self.get_sealed_secrets(cf_in, &sign_msg2.shared_key_id)?;
 	
 
-	match self.enclave().sign_second(&mut sealed_secrets, &sign_msg2) {
+	match self.enclave_mut().sign_second(&mut sealed_secrets, &sign_msg2) {
 	    Ok(x) => {
 		self.database.put_cf(cf_out, user_db_key, &x.1)?;
 		return Ok(Some(x.0))
@@ -183,7 +183,7 @@ impl Ecdsa for Lockbox {
 	let cf_out = &self.database.cf_handle("ecdsa_keyupdate").unwrap();
 	let (mut sealed_secrets, _user_db_key) = self.get_sealed_secrets(cf_in, &receiver_msg.user_id)?;
 
-	match self.enclave().keyupdate_first(&mut sealed_secrets, &receiver_msg) {
+	match self.enclave_mut().keyupdate_first(&mut sealed_secrets, &receiver_msg) {
 	    Ok(x) => {
 		let statechain_db_key = Key::from_uuid(&receiver_msg.statechain_id);
 		self.database.put_cf(cf_out, statechain_db_key, &x.1)?;

--- a/app/server/src/protocol/enclave.rs
+++ b/app/server/src/protocol/enclave.rs
@@ -15,7 +15,7 @@ pub fn enclave_hello(
 ) -> Result<Status> {
     // TODO: Add logic for health check
     let _msg = hello_message.into_inner();
-    match lockbox.enclave().say_something(_msg){
+    match lockbox.enclave_mut().say_something(_msg){
     	  Ok(_) => Ok(Status::Ok),
 	  Err(e) => Err(LockboxError::Generic(format!("enclave_hello: {}", e.to_string())).into())
     }

--- a/app/server/src/server.rs
+++ b/app/server/src/server.rs
@@ -55,7 +55,7 @@ impl Lockbox
         };
 
 	//Get the enclave id from the enclave
-	let report = lb.enclave().get_self_report().unwrap();
+	let report = lb.enclave_mut().get_self_report().unwrap();
 	let key_id = report.body.mr_enclave.m;
         let mut key_uuid = uuid::Builder::from_bytes(key_id[..16].try_into().unwrap());
         let db_key = Key::from_uuid(&key_uuid.build());
@@ -66,9 +66,9 @@ impl Lockbox
 	Ok(lb)
     }
 
-    pub fn enclave(&self) -> RwLockReadGuard<Enclave> {
-	self.enclave.read().unwrap()
-    }
+    //pub fn enclave(&self) -> RwLockReadGuard<Enclave> {
+//	self.enclave.read().unwrap()
+//    }
 
     pub fn enclave_mut(&self) -> RwLockWriteGuard<Enclave> {
 	let mut lock = self.enclave.write().expect("locking enclave to write");


### PR DESCRIPTION
Fixes poisoned lock issues. 